### PR TITLE
ログイン画面のスタイルを修正

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,7 @@ function App() {
       <main className="main">
         <authContext.Provider value={useAuthContext()}>
           <Login />
-          <BookShelf />
+          {/* <BookShelf /> */}
         </authContext.Provider>
       </main>
     </div>

--- a/frontend/src/components/AppBar/index.tsx
+++ b/frontend/src/components/AppBar/index.tsx
@@ -2,22 +2,27 @@ import React from "react";
 import "./style.scss";
 import logo from "./logo.svg";
 import titleLogo from "./logo_title.svg";
+import { useAuthContext } from "../hooks/useAuthContext";
 
 export const AppBar: React.FC = () => {
+  const { userId } = useAuthContext();
+
   return (
     <div className="app-bar">
       <img className="app-bar--logo" src={logo} alt="" />
       <img className="app-bar--title-logo" src={titleLogo} alt="" />
       <div className="spacer"></div>
-      <button
-        className="app-bar--books-register"
-        onClick={() => {
-          // TODO: クリックしたときの挙動をどうにかする
-          window.alert("本棚連携の実装");
-        }}
-      >
-        本棚連携
-      </button>
+      {userId ? (
+        <button
+          className="app-bar--books-register"
+          onClick={() => {
+            // TODO: クリックしたときの挙動をどうにかする
+            window.alert("本棚連携の実装");
+          }}
+        >
+          本棚連携
+        </button>
+      ) : null}
     </div>
   );
 };

--- a/frontend/src/components/AppBar/index.tsx
+++ b/frontend/src/components/AppBar/index.tsx
@@ -5,14 +5,14 @@ import titleLogo from "./logo_title.svg";
 import { useAuthContext } from "../hooks/useAuthContext";
 
 export const AppBar: React.FC = () => {
-  const { userId } = useAuthContext();
+  const auth = useAuthContext();
 
   return (
     <div className="app-bar">
       <img className="app-bar--logo" src={logo} alt="" />
       <img className="app-bar--title-logo" src={titleLogo} alt="" />
       <div className="spacer"></div>
-      {userId ? (
+      {auth.userId ? (
         <button
           className="app-bar--books-register"
           onClick={() => {

--- a/frontend/src/components/Login/index.tsx
+++ b/frontend/src/components/Login/index.tsx
@@ -21,18 +21,18 @@ export const Login: React.FC = () => {
         <div className="login-header">
           <p>ログイン</p>
         </div>
-        <form className="login-form login-center" onSubmit={handleSubmit}>
-          <label className="login-form-label">ユーザーID</label>
+        <form className="login-form login-center">
           <input
             className="login-form-input login-form-text"
             type="text"
-            placeholder=""
+            placeholder="ユーザーID"
             onChange={handleInputChange}
           />
           <input
             className="login-form-input login-form-submit"
-            type="submit"
+            type="button"
             value="ログイン"
+            onClick={handleSubmit}
           />
         </form>
       </div>

--- a/frontend/src/components/Login/style.scss
+++ b/frontend/src/components/Login/style.scss
@@ -7,8 +7,8 @@
     align-items: center;
   }
   &-container {
-    width: fit-content;
-    height: fit-content;
+    width: 90vw;
+    max-width: 400px;
 
     //   背景
     background-color: #eeeeee;
@@ -19,7 +19,8 @@
   &-header {
     width: 100%;
     min-width: 40vw;
-    font-size: 3rem;
+    font-size: 1.5rem;
+    font-weight: bold;
 
     & p {
       margin: 5%;
@@ -38,27 +39,42 @@
     &-input {
       width: 100%;
       min-height: 3vw;
-      font-size: 30px;
 
       // 良い感じに両端を丸くする
       border-radius: 50px;
-      border: 2px solid #ddd;
       box-sizing: border-box;
+
+      padding: 0.5rem 1rem;
 
       margin: 1vw;
     }
 
     &-text {
+      border: 2px solid #ddd;
       &:focus {
         border: 2px solid #ff9900;
         z-index: 10;
         outline: 0;
+      }
+
+      &::placeholder {
+        opacity: 0.25;
       }
     }
 
     &-submit {
       background-color: #c9a584;
       color: #eeeeee;
+      cursor: pointer;
+      border: none;
+
+      &:hover {
+        opacity: 0.75;
+      }
+
+      &:active {
+        opacity: 0.6;
+      }
     }
   }
 }


### PR DESCRIPTION
This PR will close #75 

- ログインコンポーネントのスタイルを全体に馴染むように調整した
- ログインしていないときには本棚登録ができるべきではないので、ボタンを隠した

![image](https://user-images.githubusercontent.com/6907421/133360415-8d448177-4361-4be5-bbea-42aa430b24ae.png)
